### PR TITLE
Publish release notes to Discord

### DIFF
--- a/.github/workflows/discord-release.yml
+++ b/.github/workflows/discord-release.yml
@@ -1,0 +1,70 @@
+name: Publish release to Discord
+
+on:
+  release:
+    types: [published, edited]
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Publish release notes to Discord
+        env:
+          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_RELEASE_WEBHOOK_URL }}
+          RELEASE_NAME: ${{ github.event.release.name }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          RELEASE_URL: ${{ github.event.release.html_url }}
+          RELEASE_BODY: ${{ github.event.release.body }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          if [ -z "$DISCORD_WEBHOOK_URL" ]; then
+            echo "DISCORD_RELEASE_WEBHOOK_URL is not configured; skipping Discord publish."
+            exit 0
+          fi
+
+          python3 <<'PY'
+          import json
+          import os
+          import urllib.request
+
+          webhook_url = os.environ["DISCORD_WEBHOOK_URL"]
+          release_name = os.environ.get("RELEASE_NAME") or os.environ.get("RELEASE_TAG") or "Release"
+          release_tag = os.environ.get("RELEASE_TAG", "")
+          release_url = os.environ.get("RELEASE_URL", "")
+          repository = os.environ.get("REPOSITORY", "")
+          body = (os.environ.get("RELEASE_BODY") or "").strip()
+
+          if not body:
+              body = "Release notes were not provided for this release."
+
+          max_description = 3800
+          if len(body) > max_description:
+              body = body[: max_description - 25].rstrip() + "\n\n…continued on GitHub."
+
+          title = f"{repository} {release_tag}".strip()
+          payload = {
+              "username": "Enzyme releases",
+              "embeds": [
+                  {
+                      "title": title,
+                      "url": release_url,
+                      "description": body,
+                      "color": 0x7C3AED,
+                      "footer": {"text": release_name},
+                  }
+              ],
+          }
+
+          data = json.dumps(payload).encode("utf-8")
+          request = urllib.request.Request(
+              webhook_url,
+              data=data,
+              headers={"Content-Type": "application/json"},
+              method="POST",
+          )
+          with urllib.request.urlopen(request, timeout=30) as response:
+              print(f"Discord webhook returned HTTP {response.status}")
+          PY

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,6 +38,7 @@ jobs:
         with:
           tag_name: ${{ github.ref_name }}
           name: ${{ github.ref_name }}
+          generate_release_notes: true
           files: |
             ${{ env.PLUGIN_NAME }}.zip
             main.js


### PR DESCRIPTION
## Summary
- add a shared release-event workflow that posts GitHub release notes to Discord via DISCORD_RELEASE_WEBHOOK_URL
- enable generated GitHub release notes for Obsidian plugin tag releases so the Discord message has useful body copy

## Verification
- git diff --check